### PR TITLE
Ensure toggle_readonly maintains consistent state

### DIFF
--- a/notething.pyw
+++ b/notething.pyw
@@ -996,27 +996,34 @@ class Notepad:
             self.readonly_var.set(False)
             return
 
+        # Determine the desired new state before attempting to change
+        current_state = self.readonly_var.get()
+        new_state = not current_state
+
         try:
-            if self.readonly_var.get():
+            if new_state:
                 # Make file readonly
                 os.chmod(self.current_file, 0o444)  # Read-only for all users
             else:
                 # Make file writable
                 os.chmod(self.current_file, 0o666)  # Read-write for all users
-            
+
+            # Update internal state only after successful permission change
+            self.readonly_var.set(new_state)
+
             # Update window title
             self._update_title()
-            
+
             # Update status bar
-            status = "read-only" if self.readonly_var.get() else "writable"
+            status = "read-only" if new_state else "writable"
             status_text = f"Status: File is now {status}"
             self.status_bar.config(text=status_text)
             self.tooltip.set_text(status_text)
-            
+
         except Exception as e:
             messagebox.showerror("Permission Error", f"Could not change file permissions:\n{e}")
-            # Revert the checkbox state
-            self.readonly_var.set(not self.readonly_var.get())
+            # Revert the checkbox state to the previous value
+            self.readonly_var.set(current_state)
 
     def save_file(self):
         if self.current_file:  # If a file is already opened


### PR DESCRIPTION
## Summary
- Compute intended read-only state before applying chmod
- Update internal variable, status bar, and window title only after successful permission change
- Restore previous state if permission change fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'notething')*


------
https://chatgpt.com/codex/tasks/task_e_68aea219a9b883268be08001c5ccad25